### PR TITLE
fix: Fixed a crash when opening the recipe view tab order GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [5.2.1]
+- Fixed a crash when opening the recipe view tab order GUI 
+
 ## [5.2.0]
 - Added a new event, called HMIItemListRefreshEvent. Entrypoint is `hmifabric:item_list_refresh`
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@ org.gradle.daemon=false
     modmenu_version=v1.8.5-beta.3
 
 # Mod Properties
-    mod_version = 5.2.1
+    mod_version = 5.2.2
     maven_group = net.glasslauncher
     archives_base_name = HMI-Fabric-Unofficial

--- a/src/main/java/net/glasslauncher/hmifabric/GuiTabOrder.java
+++ b/src/main/java/net/glasslauncher/hmifabric/GuiTabOrder.java
@@ -43,9 +43,9 @@ public class GuiTabOrder extends Screen {
         top = 32;
         slotHeight = 21;
         currentTabs = HowManyItemsClient.getTabs();
+        allTabs = HowManyItemsClient.getTabs();
         newOrder = new Tab[allTabs.size()];
         tabEnabled = new boolean[allTabs.size()];
-        allTabs = HowManyItemsClient.getTabs();
     }
 
     @Override


### PR DESCRIPTION
allTabs was being initialized AFTER calls to allTabs.size(), and this led to unsavoury results