### PR TITLE
Modernize

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,22 @@
 plugins {
+    id 'idea'
+    id 'java-library'
     id 'maven-publish'
-    id 'babric-loom' version '1.0.1'
+    id "fabric-loom" version "1.9-SNAPSHOT"
+    id "babric-loom-extension" version "1.9-SNAPSHOT"
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+tasks.withType(JavaCompile).configureEach {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
-archivesBaseName = project.archives_base_name
+base {
+    archivesBaseName = project.archives_base_name
+}
+
 version = project.mod_version
 group = project.maven_group
-
-loom {
-    gluedMinecraftJar()
-    customMinecraftManifest.set("https://babric.github.io/manifest-polyfill/${minecraft_version}.json")
-    intermediaryUrl.set("https://maven.glass-launcher.net/babric/babric/intermediary/%1\$s/intermediary-%1\$s-v2.jar")
-}
 
 idea {
     module {
@@ -77,7 +79,7 @@ dependencies {
     // to change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.glasslauncher:biny:${project.yarn_mappings}:v2"
-    modImplementation "babric:fabric-loader:${project.loader_version}"
+    modApi "net.fabricmc:fabric-loader:${project.loader_version}"
 
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.2'
 
@@ -136,10 +138,6 @@ publishing {
         mavenLocal()
         maven {
             url = "https://maven.glass-launcher.net/releases"
-            credentials {
-                username "${project.glass_maven_username}"
-                password "${project.glass_maven_password}"
-            }
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'idea'
-    id 'java-library'
     id 'maven-publish'
     id "fabric-loom" version "1.9-SNAPSHOT"
     id "babric-loom-extension" version "1.9-SNAPSHOT"
@@ -12,7 +11,7 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 base {
-    archivesBaseName = project.archives_base_name
+    archivesName.set project.archives_base_name
 }
 
 version = project.mod_version
@@ -33,23 +32,23 @@ eclipse {
 repositories {
     maven {
         name = "Glass Snapshots"
-        url "https://maven.glass-launcher.net/snapshots"
+        url = "https://maven.glass-launcher.net/snapshots"
     }
     maven {
         name = "Glass Releases"
-        url "https://maven.glass-launcher.net/releases"
+        url = "https://maven.glass-launcher.net/releases"
     }
     maven {
         name = "Babric"
-        url "https://maven.glass-launcher.net/babric"
+        url = "https://maven.glass-launcher.net/babric"
     }
     maven {
         name = 'Froge'
-        url 'https://maven.minecraftforge.net/'
+        url = 'https://maven.minecraftforge.net/'
     }
     maven {
         name = "Jitpack"
-        url "https://jitpack.io/"
+        url = "https://jitpack.io/"
     }
     mavenCentral()
     exclusiveContent {
@@ -94,7 +93,7 @@ dependencies {
     }
 
     modImplementation("com.github.calmilamsy:ModMenu:${project.modmenu_version}") {
-        transitive false
+        transitive = false
     }
 
     implementation("me.carleslc:Simple-Yaml:1.8.4")
@@ -128,7 +127,7 @@ java {
 
 jar {
     from("LICENSE") {
-        rename { "${it}_${project.archivesBaseName}" }
+        rename { "${it}_${base.archivesName}" }
     }
 }
 
@@ -143,9 +142,9 @@ publishing {
 
     publications {
         mavenJava(MavenPublication) {
-            artifactId "HowManyItems-Fabric-Unofficial"
-            artifact ("${project.buildDir.absolutePath}/libs/${archivesBaseName}-${project.version}.jar") {
-                classifier null
+            artifactId = "HowManyItems-Fabric-Unofficial"
+            artifact ("${project.buildDir.absolutePath}/libs/${base.archivesName}-${project.version}.jar") {
+                classifier = null
                 builtBy remapJar
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ dependencies {
         transitive false
     }
 
-    implementation "blue.endless:jankson:1.2.1"
+    implementation("me.carleslc:Simple-Yaml:1.8.4")
     modImplementation("net.glasslauncher.mods:GlassConfigAPI:${project.gcapi_version}") {
         exclude module: "StationAPI"
         exclude module: "fabric-loader"

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,13 +5,13 @@ org.gradle.daemon=false
 # Fabric Properties
 # check these on https://fabricmc.net/use
     minecraft_version=b1.7.3
-    yarn_mappings=b1.7.3+a00e3b0
-    loader_version=0.14.19-babric.1
-    stapi_version=2.0-alpha.1
+    yarn_mappings=b1.7.3+0ff7479
+    loader_version=0.16.9
+    stapi_version=2.0.0-alpha.3
     gcapi_version=1.2.0
     modmenu_version=v1.8.5-beta.3
 
 # Mod Properties
-    mod_version = 5.2.1
+    mod_version = 5.3.0
     maven_group = net.glasslauncher
     archives_base_name = HMI-Fabric-Unofficial

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.daemon=false
     yarn_mappings=b1.7.3+0ff7479
     loader_version=0.16.9
     stapi_version=2.0.0-alpha.3
-    gcapi_version=1.2.0
+    gcapi_version=3.0.0
     modmenu_version=v1.8.5-beta.3
 
 # Mod Properties

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sun Jun 14 19:21:24 BST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,15 +2,15 @@ pluginManagement {
     repositories {
         maven {
             name = "Fabrick"
-            url "https://maven.fabricmc.net"
+            url = "https://maven.fabricmc.net"
         }
         maven {
             name = "Babric"
-            url "https://maven.glass-launcher.net/babric"
+            url = "https://maven.glass-launcher.net/babric"
         }
         maven {
             name = "Jitpack"
-            url "https://jitpack.io/"
+            url = "https://jitpack.io/"
         }
         mavenCentral()
         gradlePluginPortal()

--- a/src/main/java/net/glasslauncher/hmifabric/Config.java
+++ b/src/main/java/net/glasslauncher/hmifabric/Config.java
@@ -1,19 +1,15 @@
 package net.glasslauncher.hmifabric;
 
-import blue.endless.jankson.Comment;
-import blue.endless.jankson.JsonObject;
-import blue.endless.jankson.JsonPrimitive;
 import net.glasslauncher.hmifabric.tabs.Tab;
 import net.glasslauncher.hmifabric.tabs.TabRegistry;
-import net.glasslauncher.mods.api.gcapi.api.ConfigName;
-import net.glasslauncher.mods.api.gcapi.api.GCAPI;
-import net.glasslauncher.mods.api.gcapi.api.GConfig;
-import net.glasslauncher.mods.api.gcapi.api.MultiplayerSynced;
-import net.glasslauncher.mods.api.gcapi.impl.ConfigFactories;
-import net.modificationstation.stationapi.api.util.Identifier;
+import net.glasslauncher.mods.gcapi3.api.ConfigEntry;
+import net.glasslauncher.mods.gcapi3.api.ConfigRoot;
+import net.glasslauncher.mods.gcapi3.api.GCAPI;
+import net.glasslauncher.mods.gcapi3.impl.ConfigFactories;
 
 import java.lang.reflect.*;
 import java.util.*;
+import net.glasslauncher.mods.gcapi3.impl.GlassYamlFile;
 
 public class Config {
 
@@ -60,68 +56,62 @@ public class Config {
 
     public static void writeConfig() {
         try {
-            JsonObject jsonObject = new JsonObject();
-            for (Field field : ConfigFields.class.getDeclaredFields()) {
-                jsonObject.put(field.getName(), ConfigFactories.saveFactories.get(field.getType()).apply(field.get(config)));
+            GlassYamlFile cfg = new GlassYamlFile();
+            for (Field field : ConfigFields.class.getFields()) {
+                cfg.set(field.getName(), ConfigFactories.saveFactories.get(field.getType()).apply(field.get(config)));
             }
-            jsonObject.put("forceNotMultiplayer", new JsonPrimitive(true));
-            GCAPI.reloadConfig(Identifier.of("hmifabric:config"), jsonObject.toJson());
+            cfg.set("forceNotMultiplayer", true);
+            GCAPI.reloadConfig("hmifabric:config", cfg);
         } catch (IllegalAccessException e) {
             e.printStackTrace();
         }
     }
 
-    @GConfig(value = "config", visibleName = "HMI Config")
-    public static ConfigFields config = new ConfigFields();
+    @ConfigRoot(value = "config", visibleName = "HMI Config")
+    public static final ConfigFields config = new ConfigFields();
 
     public static boolean isHMIServer = false;
 
     public static class ConfigFields {
-        @ConfigName("Overlay Enabled")
+        @ConfigEntry(name = "Overlay Enabled")
         public Boolean overlayEnabled = true;
-        @ConfigName("Cheats Enabled")
+        @ConfigEntry(name = "Cheats Enabled")
         public Boolean cheatsEnabled = false;
-        @ConfigName("Show Item IDs")
+        @ConfigEntry(name = "Show Item IDs")
         public Boolean showItemIDs = false;
-        @ConfigName("Center Search Bar")
+        @ConfigEntry(name = "Center Search Bar")
         public Boolean centredSearchBar = false;
-        @ConfigName("Fast Search")
+        @ConfigEntry(name = "Fast Search")
         public Boolean fastSearch = false;
-        @ConfigName("Inverted Scrolling")
+        @ConfigEntry(name = "Inverted Scrolling")
         public Boolean scrollInverted = false;
 
-        @MultiplayerSynced
-        @ConfigName("Multiplayer Give Command")
+        @ConfigEntry(name = "Multiplayer Give Command", multiplayerSynced = true)
         public String mpGiveCommand = "/give {0} {1} {2}";
-        @MultiplayerSynced
-        @ConfigName("Multiplayer Heal Command")
+        @ConfigEntry(name = "Multiplayer Heal Command", multiplayerSynced = true)
         public String mpHealCommand = "";
-        @MultiplayerSynced
-        @ConfigName("Multiplayer Time Day Command")
+        @ConfigEntry(name = "Multiplayer Time Day Command", multiplayerSynced = true)
         public String mpTimeDayCommand = "/time set 0";
-        @MultiplayerSynced
-        @ConfigName("Multiplayer Time Night Command")
+        @ConfigEntry(name = "Multiplayer Time Night Command", multiplayerSynced = true)
         public String mpTimeNightCommand = "/time set 13000";
-        @MultiplayerSynced
-        @ConfigName("Multiplayer Rain On Command")
+        @ConfigEntry(name = "Multiplayer Rain On Command", multiplayerSynced = true)
         public String mpRainONCommand = "";
-        @MultiplayerSynced
-        @ConfigName("Multiplayer Rain Off Command")
+        @ConfigEntry(name = "Multiplayer Rain Off Command", multiplayerSynced = true)
         public String mpRainOFFCommand = "";
 
-        @ConfigName("Draggable Recipe Viewer")
+        @ConfigEntry(name = "Draggable Recipe Viewer")
         public Boolean recipeViewerDraggableGui = false;
-        @ConfigName("Show Null Name Items")
-        @Comment("Shows items with null names. Can cause crashes with poorly made mods.")
+        @ConfigEntry(name = "Show Null Name Items",
+                     comment = "Shows items with null names. Can cause crashes with poorly made mods.")
         public Boolean hideNullNames = false;
 
-        @ConfigName("Developer Mode")
-        @Comment("Enables some extra tooltips. Breaks relatively easily, but shouldn't cause crashes.")
+        @ConfigEntry(name = "Developer Mode",
+                     comment = "Enables some extra tooltips. Breaks relatively easily, but shouldn't cause crashes.")
         public Boolean devMode = false;
 
-        @ConfigName("Recipe Viewer GUI Width")
+        @ConfigEntry(name = "Recipe Viewer GUI Width", maxLength = Integer.MAX_VALUE)
         public Integer recipeViewerGuiWidth = 251;
-        @ConfigName("Recipe Viewer GUI Height")
+        @ConfigEntry(name = "Recipe Viewer GUI Height", maxLength = Integer.MAX_VALUE)
         public Integer recipeViewerGuiHeight = 134;
     }
 }

--- a/src/main/java/net/glasslauncher/hmifabric/ContainerRecipeViewer.java
+++ b/src/main/java/net/glasslauncher/hmifabric/ContainerRecipeViewer.java
@@ -1,11 +1,11 @@
 package net.glasslauncher.hmifabric;
 
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.inventory.Container;
+import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.Slot;
 
 
-public class ContainerRecipeViewer extends Container {
+public class ContainerRecipeViewer extends ScreenHandler {
 
     public ContainerRecipeViewer(InventoryRecipeViewer iinventory) {
         //setting the windowId to -1 prevents server registering recipe clicks as inventory clicks
@@ -21,11 +21,11 @@ public class ContainerRecipeViewer extends Container {
 
     // Not an override. Custom method.
     public void addSlot(int i, int j) {
-        method_2079(new Slot(inv, count++, i, j));
+        addSlot(new Slot(inv, count++, i, j));
     }
 
     @Override
-    public boolean method_2094(PlayerEntity entityplayer) {
+    public boolean canUse(PlayerEntity entityplayer) {
         return inv.canPlayerUse(entityplayer);
     }
 

--- a/src/main/java/net/glasslauncher/hmifabric/GuiButtonHMI.java
+++ b/src/main/java/net/glasslauncher/hmifabric/GuiButtonHMI.java
@@ -36,12 +36,12 @@ public class GuiButtonHMI extends ButtonWidget {
         Utils.bindTexture("/gui/gui.png");
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         boolean isHovered = i >= x && j >= y && i < x + width && j < y + height;
-        int k = method_1187(isHovered);
+        int k = getYImage(isHovered);
         drawTexture(x, y, 0, 46 + k * 20, width / 2, height);
         drawTexture(x + width / 2, y, 200 - width / 2, 46 + k * 20, width / 2, height / 2);
         drawTexture(x, y + height / 2, 0, 46 + k * 20 + 20 - height / 2, width / 2, height / 2);
         drawTexture(x + width / 2, y + height / 2, 200 - width / 2, 46 + k * 20 + 20 - height / 2, width / 2, height / 2);
-        method_1188(minecraft, i, j);
+        renderBackground(minecraft, i, j);
         if (item != null && (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT))) {
             Utils.drawItemStack(x + 2, y + 2, item, true);
         } else if (iconIndex < 0) {

--- a/src/main/java/net/glasslauncher/hmifabric/GuiOverlay.java
+++ b/src/main/java/net/glasslauncher/hmifabric/GuiOverlay.java
@@ -64,7 +64,7 @@ public class GuiOverlay extends Screen {
         lastKeyTimeout = System.currentTimeMillis() + 200L;
         lastKey = Keyboard.getEventKey();
 
-        if(HowManyItemsClient.getTabs().size() > 0) guiBlock = TabUtils.getItemFromGui(screen);
+        if(!HowManyItemsClient.getTabs().isEmpty()) guiBlock = TabUtils.getItemFromGui(screen);
 
         init(Utils.getMC(), screen.width, screen.height);
 
@@ -127,9 +127,8 @@ public class GuiOverlay extends Screen {
         int w = screen.width - (screen.width - xSize) / 2 - xSize - 1;
 
         Utils.disableLighting();
-        for(int kx = 0; kx < buttons.size(); kx++)
-        {
-            ((ButtonWidget)buttons.get(kx)).render(minecraft, posX, posY);
+        for (Object button : buttons) {
+            ((ButtonWidget) button).render(minecraft, posX, posY);
         }
         searchBox.render();
 
@@ -137,7 +136,7 @@ public class GuiOverlay extends Screen {
 
         int x = 0;
         int y = 0;
-        Boolean itemHovered = false;
+        boolean itemHovered = false;
         PlayerInventory inventoryplayer = minecraft.player.inventory;
         int canvasHeight = screen.height - BUTTON_HEIGHT * 2;
         if(Config.config.centredSearchBar) canvasHeight += BUTTON_HEIGHT;
@@ -226,8 +225,7 @@ public class GuiOverlay extends Screen {
                         hiddenItems.add(currentItem);
                 }
                 else {
-                    if(hiddenItems.contains(currentItem))
-                        hiddenItems.remove(hiddenItems.indexOf(currentItem));
+                    hiddenItems.remove(currentItem);
                 }
             }
             draggingFrom = null;
@@ -293,7 +291,7 @@ public class GuiOverlay extends Screen {
         }
         else if(buttonOptions.isMouseOver(minecraft, posX, posY))
         {
-            if(!shiftHeld || HowManyItemsClient.getTabs().size() == 0) {
+            if(!shiftHeld || HowManyItemsClient.getTabs().isEmpty()) {
                 s = "Settings";
             }
             else if(guiBlock != null) {
@@ -398,7 +396,7 @@ public class GuiOverlay extends Screen {
                                 customData.objects = new Object[] {spawnedItem};
                                 PacketHelper.send(customData);
                             }
-                            else if(Config.config.mpGiveCommand.length() > 0) {
+                            else if(!Config.config.mpGiveCommand.isEmpty()) {
                                 NumberFormat numberformat = NumberFormat.getIntegerInstance();
                                 numberformat.setGroupingUsed(false);
                                 MessageFormat messageformat = new MessageFormat(Config.config.mpGiveCommand);
@@ -406,7 +404,7 @@ public class GuiOverlay extends Screen {
                                 messageformat.setFormatByArgumentIndex(2, numberformat);
                                 messageformat.setFormatByArgumentIndex(3, numberformat);
                                 Object aobj[] = {
-                                        minecraft.player.name, hoverItem.itemId, (eventButton == 0) ? hoverItem.getMaxCount() : 1, Integer.valueOf(hoverItem.getDamage())
+                                        minecraft.player.name, hoverItem.itemId, (eventButton == 0) ? hoverItem.getMaxCount() : 1, hoverItem.getDamage()
                                 };
                                 minecraft.player.sendChatMessage(messageformat.format((aobj)));
                             }

--- a/src/main/java/net/glasslauncher/hmifabric/GuiOverlay.java
+++ b/src/main/java/net/glasslauncher/hmifabric/GuiOverlay.java
@@ -110,7 +110,7 @@ public class GuiOverlay extends Screen {
 
     public void drawScreen(int posX, int posY) {
         boolean shiftHeld = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
-        if(shiftHeld && HowManyItemsClient.getTabs().size() > 0) {
+        if(shiftHeld && !HowManyItemsClient.getTabs().isEmpty()) {
             buttonOptions.iconIndex = 2;
             if(buttonTrash != null) {
                 buttonTrash.text = "Delete ALL";
@@ -257,6 +257,7 @@ public class GuiOverlay extends Screen {
         if (inventoryplayer.getCursorStack() == null && hoverItem != null) {
             if(!showHiddenItems) {
                 s = Utils.getNiceItemName(hoverItem);
+                Utils.setTooltipData(hoverItem, inventoryplayer);
             }
             else {
                 if(draggingFrom != null && draggingFrom != hoverItem) {
@@ -333,7 +334,7 @@ public class GuiOverlay extends Screen {
                 else s = "Delete " + Utils.getNiceItemName(inventoryplayer.getCursorStack());
             }
         }
-        if(s.length() > 0)
+        if(!s.isEmpty())
         {
             int k1 = posX;
             int i2 = posY;
@@ -351,24 +352,16 @@ public class GuiOverlay extends Screen {
         else if(inventoryplayer.getCursorStack() == null && Utils.hoveredItem(screen, posX, posY) != null) {
             ItemStack item = Utils.hoveredItem(screen, posX, posY);
             s = TranslationStorage.getInstance().getClientTranslation(item.getTranslationKey());
-            int k1 = posX;
-            int i2 = posY;
-            int j2 = textRenderer.getWidth(s);
-            if(k1 + 9 <= k && k1 + j2 + 15 > k) {
-                Utils.drawRect(k, i2 - 15, k1 + j2 + 15, i2 - 1, 0xc0000000);
-                textRenderer.drawWithShadow(s, k1 + 12, i2 - 12, -1);
-            }
             if(s.isEmpty()) {
-                Utils.drawTooltip(Utils.getNiceItemName(item), k1, i2);
+                s = Utils.getNiceItemName(item);
             }
             else if(Config.config.showItemIDs) {
-                s = " " + item.itemId;
+                s += " " + item.itemId;
                 /*if(item.hasSubtypes())*/ s+= ":" + item.getDamage();
                 if (item.getItem().isDamageable()) s+= "/" + item.getItem().getMaxDamage();
-                int j3 = textRenderer.getWidth(s);
-                Utils.drawRect(k1 + j2 + 15, i2 - 15, k1 + j2 + j3 + 15, i2 + 8 - 9, 0xc0000000);
-                textRenderer.drawWithShadow(s, k1 + j2 + 12, i2 - 12, -1);
             }
+            Utils.drawTooltip(s, posX, posY);
+            Utils.setTooltipData(item, inventoryplayer);
         }
     }
 

--- a/src/main/java/net/glasslauncher/hmifabric/GuiOverlay.java
+++ b/src/main/java/net/glasslauncher/hmifabric/GuiOverlay.java
@@ -491,7 +491,7 @@ public class GuiOverlay extends Screen {
             decIndex();
         }
         else if(guibutton == buttonOptions) {
-            if(shiftHeld && HowManyItemsClient.getTabs().size() > 0) {
+            if(shiftHeld && !HowManyItemsClient.getTabs().isEmpty()) {
                 if(guiBlock == null) {
                     HowManyItemsClient.pushRecipe(screen, null, true);
                 }
@@ -601,7 +601,7 @@ public class GuiOverlay extends Screen {
     {
         if(!searchBoxFocused() && Config.config.fastSearch && !HowManyItemsClient.keyHeldLastTick) {
             if(!Utils.keyEquals(i, minecraft.options.inventoryKey) && !Utils.keyEquals(i, KeyBindings.allRecipes) && !Utils.keyEquals(i, KeyBindings.toggleOverlay)
-                    && (CharacterUtils.VALID_CHARACTERS.indexOf(c) >= 0 || (i == Keyboard.KEY_BACK && searchBox.getText().length() > 0))) {
+                    && (CharacterUtils.VALID_CHARACTERS.indexOf(c) >= 0 || (i == Keyboard.KEY_BACK && !searchBox.getText().isEmpty()))) {
                 ScreenScaler scaledresolution = new ScreenScaler(minecraft.options, minecraft.displayWidth, minecraft.displayHeight);
                 int i2 = scaledresolution.getScaledWidth();
                 int j2 = scaledresolution.getScaledHeight();
@@ -624,7 +624,7 @@ public class GuiOverlay extends Screen {
             if(searchBox.getText().length() > lastSearch.length()) {
                 prevSearches.push(currentItems);
                 currentItems = getCurrentList(currentItems);
-            }else if(searchBox.getText().length() == 0) {
+            }else if(searchBox.getText().isEmpty()) {
                 resetItems();
             }
             else if(searchBox.getText().length() < lastSearch.length()) {
@@ -645,7 +645,7 @@ public class GuiOverlay extends Screen {
                             if (screen instanceof GuiRecipeViewer) {
                                 ((GuiRecipeViewer) screen).push(null, false);
                             }
-                            else if (HowManyItemsClient.getTabs().size() > 0){
+                            else if (!HowManyItemsClient.getTabs().isEmpty()){
                                 GuiRecipeViewer newgui = new GuiRecipeViewer(null, false, screen);
                                 minecraft.currentScreen = newgui;
                                 ScreenScaler scaledresolution = new ScreenScaler(minecraft.options, minecraft.displayWidth, minecraft.displayHeight);
@@ -782,7 +782,7 @@ public class GuiOverlay extends Screen {
     private static ArrayList<ItemStack> getCurrentList(ArrayList<ItemStack> listToSearch){
         index = 0;
         ArrayList<ItemStack> newList = new ArrayList<>();
-        if(searchBox != null && searchBox.getText().length() > 0) {
+        if(searchBox != null && !searchBox.getText().isEmpty()) {
             for(ItemStack currentItem : listToSearch) {
                 String s = (TranslationStorage.getInstance().getClientTranslation(currentItem.getTranslationKey()));
                 if(s.toLowerCase().contains(searchBox.getText().toLowerCase()) && (showHiddenItems || !hiddenItems.contains(currentItem)) && (Config.config.hideNullNames || !Utils.getNiceItemName(currentItem).endsWith("null"))) {
@@ -840,7 +840,7 @@ public class GuiOverlay extends Screen {
 
     public static boolean emptySearchBox() {
         if(searchBox != null) {
-            return searchBox.getText().length() == 0;
+            return searchBox.getText().isEmpty();
         }
         return false;
     }

--- a/src/main/java/net/glasslauncher/hmifabric/GuiRecipeViewer.java
+++ b/src/main/java/net/glasslauncher/hmifabric/GuiRecipeViewer.java
@@ -396,7 +396,7 @@ public class GuiRecipeViewer extends HandledScreen {
                         && (cursorPosY > y - 16) && (cursorPosY < y)) {
 
                     String s2 = (tabs.get(z).name());
-                    if (s2.length() > 0) {
+                    if (!s2.isEmpty()) {
                         Utils.drawTooltip(s2, cursorPosX, cursorPosY);
                     }
                     break;

--- a/src/main/java/net/glasslauncher/hmifabric/GuiRecipeViewer.java
+++ b/src/main/java/net/glasslauncher/hmifabric/GuiRecipeViewer.java
@@ -3,11 +3,11 @@ package net.glasslauncher.hmifabric;
 import net.glasslauncher.hmifabric.mixin.access.ContainerBaseAccessor;
 import net.glasslauncher.hmifabric.tabs.Tab;
 import net.glasslauncher.hmifabric.tabs.TabWithTexture;
-import net.minecraft.class_564;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.container.ContainerScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.OptionButtonWidget;
+import net.minecraft.client.util.ScreenScaler;
 import net.minecraft.item.ItemStack;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
@@ -15,7 +15,7 @@ import org.lwjgl.input.Mouse;
 import java.util.*;
 
 
-public class GuiRecipeViewer extends ContainerScreen {
+public class GuiRecipeViewer extends HandledScreen {
     public GuiRecipeViewer(ItemStack itemstack, Boolean getUses, Screen parent) {
         super(container = new ContainerRecipeViewer(inv = new InventoryRecipeViewer(itemstack)));
         this.parent = parent;
@@ -35,7 +35,7 @@ public class GuiRecipeViewer extends ContainerScreen {
             backgroundWidth = Config.config.recipeViewerGuiWidth;
             backgroundHeight = Config.config.recipeViewerGuiHeight;
         } else {
-            if (parent instanceof ContainerScreen) {
+            if (parent instanceof HandledScreen) {
                 try {
                     backgroundWidth = ((ContainerBaseAccessor) parent).getContainerWidth();
                 } catch (Exception e) {
@@ -84,7 +84,7 @@ public class GuiRecipeViewer extends ContainerScreen {
         }
         if (inv.filter.isEmpty() || getUses != inv.prevGetUses.peek() ||
                 (itemstack == null && inv.filter.peek() != null) || (itemstack != null && inv.filter.peek() == null) ||
-                (itemstack.itemId != inv.filter.peek().itemId || (itemstack.getDamage() != inv.filter.peek().getDamage() && itemstack.method_719()))) {
+                (itemstack.itemId != inv.filter.peek().itemId || (itemstack.getDamage() != inv.filter.peek().getDamage() && itemstack.hasSubtypes()))) {
 
             inv.newList = true;
             if (itemstack == null) {
@@ -263,7 +263,7 @@ public class GuiRecipeViewer extends ContainerScreen {
         }
         if (i == Keyboard.KEY_ESCAPE || i == minecraft.options.inventoryKey.code) {
             displayParent();
-            if (i == minecraft.options.inventoryKey.code) minecraft.player.closeScreen();
+            if (i == minecraft.options.inventoryKey.code) minecraft.player.closeHandledScreen();
         } else
             super.keyPressed(c, i);
     }
@@ -355,15 +355,15 @@ public class GuiRecipeViewer extends ContainerScreen {
     public void displayParent() {
         //if (parent instanceof GuiInventory) {
         minecraft = Utils.getMC();
-        minecraft.player.container = minecraft.player.playerContainer;
+        minecraft.player.currentScreenHandler = minecraft.player.playerScreenHandler;
         //}
         this.removed();
         if (parent != null) {
             minecraft.currentScreen = parent;
-            class_564 scaledresolution = new class_564(minecraft.options, minecraft.displayWidth, minecraft.displayHeight);
-            int i = scaledresolution.method_1857();
-            int j = scaledresolution.method_1858();
-            minecraft.method_2134();
+            ScreenScaler scaledresolution = new ScreenScaler(minecraft.options, minecraft.displayWidth, minecraft.displayHeight);
+            int i = scaledresolution.getScaledWidth();
+            int j = scaledresolution.getScaledHeight();
+            minecraft.unlockMouse();
             parent.init(minecraft, i, j);
         } else {
             minecraft.setScreen(parent);

--- a/src/main/java/net/glasslauncher/hmifabric/HowManyItemsClient.java
+++ b/src/main/java/net/glasslauncher/hmifabric/HowManyItemsClient.java
@@ -8,6 +8,7 @@ import net.glasslauncher.hmifabric.tabs.Tab;
 import net.glasslauncher.hmifabric.tabs.TabCrafting;
 import net.glasslauncher.hmifabric.tabs.TabRegistry;
 import net.glasslauncher.hmifabric.tabs.TabSmelting;
+import net.mine_diver.unsafeevents.event.PhaseOrdering;
 import net.mine_diver.unsafeevents.listener.EventListener;
 import net.mine_diver.unsafeevents.listener.ListenerPriority;
 import net.minecraft.block.Block;
@@ -20,6 +21,7 @@ import net.modificationstation.stationapi.api.StationAPI;
 import net.modificationstation.stationapi.api.client.event.gui.screen.container.TooltipRenderEvent;
 import net.modificationstation.stationapi.api.client.event.network.MultiplayerLogoutEvent;
 import net.modificationstation.stationapi.api.client.event.option.KeyBindingRegisterEvent;
+import net.modificationstation.stationapi.api.event.init.InitFinishedEvent;
 import net.modificationstation.stationapi.api.event.registry.MessageListenerRegistryEvent;
 import net.modificationstation.stationapi.api.mod.entrypoint.Entrypoint;
 import net.modificationstation.stationapi.api.registry.Registry;
@@ -240,7 +242,15 @@ public class HowManyItemsClient {
         event.registry.addEquivalentCraftingStation(Identifier.of(Namespace.MINECRAFT, "smelting"), new ItemStack(Block.LIT_FURNACE));
     }
 
-    @EventListener(phase = StationAPI.INTERNAL_PHASE, priority = ListenerPriority.HIGHEST)
+    public static final String HMI_TOOLTIP_PHASE = "hmifabric:tooltip_phase";
+
+    @EventListener(priority = ListenerPriority.LOW)
+    public static void initAMI(InitFinishedEvent e) {
+        //noinspection UnstableApiUsage
+        PhaseOrdering.of(TooltipRenderEvent.class).addPhaseOrdering(HMI_TOOLTIP_PHASE, StationAPI.INTERNAL_PHASE);
+    }
+
+    @EventListener(phase = HMI_TOOLTIP_PHASE)
     public void disableVanillaTooltips(TooltipRenderEvent e) {
         if (e.container != null) {
             e.setCanceled(true);

--- a/src/main/java/net/glasslauncher/hmifabric/HowManyItemsClient.java
+++ b/src/main/java/net/glasslauncher/hmifabric/HowManyItemsClient.java
@@ -9,12 +9,15 @@ import net.glasslauncher.hmifabric.tabs.TabCrafting;
 import net.glasslauncher.hmifabric.tabs.TabRegistry;
 import net.glasslauncher.hmifabric.tabs.TabSmelting;
 import net.mine_diver.unsafeevents.listener.EventListener;
+import net.mine_diver.unsafeevents.listener.ListenerPriority;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.util.ScreenScaler;
 import net.minecraft.item.ItemStack;
+import net.modificationstation.stationapi.api.StationAPI;
+import net.modificationstation.stationapi.api.client.event.gui.screen.container.TooltipRenderEvent;
 import net.modificationstation.stationapi.api.client.event.network.MultiplayerLogoutEvent;
 import net.modificationstation.stationapi.api.client.event.option.KeyBindingRegisterEvent;
 import net.modificationstation.stationapi.api.event.registry.MessageListenerRegistryEvent;
@@ -65,8 +68,7 @@ public class HowManyItemsClient {
     }
 
     public void onTickInGUI(Minecraft mc, Screen guiscreen) {
-        if (guiscreen instanceof HandledScreen) {
-            HandledScreen screen = (HandledScreen) guiscreen;
+        if (guiscreen instanceof HandledScreen screen) {
             if (Config.config.overlayEnabled) {
                 if (GuiOverlay.screen != screen || overlay == null || screen.width != overlay.width || screen.height != overlay.height) {
                     overlay = new GuiOverlay(screen);
@@ -151,7 +153,7 @@ public class HowManyItemsClient {
         if (Utils.getMC().player.inventory.getCursorStack() == null) {
             if (gui instanceof GuiRecipeViewer) {
                 ((GuiRecipeViewer) gui).push(item, getUses);
-            } else if (!GuiOverlay.searchBoxFocused() && getTabs().size() > 0) {
+            } else if (!GuiOverlay.searchBoxFocused() && !getTabs().isEmpty()) {
                 GuiRecipeViewer newgui = new GuiRecipeViewer(item, getUses, gui);
                 Utils.getMC().currentScreen = newgui;
                 ScreenScaler scaledresolution = new ScreenScaler(Utils.getMC().options, Utils.getMC().displayWidth, Utils.getMC().displayHeight);

--- a/src/main/java/net/glasslauncher/hmifabric/HowManyItemsClient.java
+++ b/src/main/java/net/glasslauncher/hmifabric/HowManyItemsClient.java
@@ -237,4 +237,11 @@ public class HowManyItemsClient {
         event.registry.register(Identifier.of(Namespace.MINECRAFT, "smelting"), new TabSmelting(HowManyItems.MODID), new ItemStack(Block.FURNACE));
         event.registry.addEquivalentCraftingStation(Identifier.of(Namespace.MINECRAFT, "smelting"), new ItemStack(Block.LIT_FURNACE));
     }
+
+    @EventListener(phase = StationAPI.INTERNAL_PHASE, priority = ListenerPriority.HIGHEST)
+    public void disableVanillaTooltips(TooltipRenderEvent e) {
+        if (e.container != null) {
+            e.setCanceled(true);
+        }
+    }
 }

--- a/src/main/java/net/glasslauncher/hmifabric/HowManyItemsClient.java
+++ b/src/main/java/net/glasslauncher/hmifabric/HowManyItemsClient.java
@@ -170,7 +170,7 @@ public class HowManyItemsClient {
     public static void pushTabBlock(Screen gui, ItemStack item) {
         if (gui instanceof GuiRecipeViewer) {
             ((GuiRecipeViewer) gui).pushTabBlock(item);
-        } else if (!GuiOverlay.searchBoxFocused() && getTabs().size() > 0) {
+        } else if (!GuiOverlay.searchBoxFocused() && !getTabs().isEmpty()) {
             Utils.getMC().lockMouse();
             GuiRecipeViewer newgui = new GuiRecipeViewer(item, gui);
             Utils.getMC().currentScreen = newgui;

--- a/src/main/java/net/glasslauncher/hmifabric/HowManyItemsClient.java
+++ b/src/main/java/net/glasslauncher/hmifabric/HowManyItemsClient.java
@@ -10,11 +10,10 @@ import net.glasslauncher.hmifabric.tabs.TabRegistry;
 import net.glasslauncher.hmifabric.tabs.TabSmelting;
 import net.mine_diver.unsafeevents.listener.EventListener;
 import net.minecraft.block.Block;
-import net.minecraft.class_564;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.container.ContainerScreen;
-import net.minecraft.inventory.Container;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.util.ScreenScaler;
 import net.minecraft.item.ItemStack;
 import net.modificationstation.stationapi.api.client.event.network.MultiplayerLogoutEvent;
 import net.modificationstation.stationapi.api.client.event.option.KeyBindingRegisterEvent;
@@ -45,11 +44,11 @@ public class HowManyItemsClient {
         event.keyBindings.add(KeyBindings.toggleOverlay);
     }
 
-    public static void addGuiToBlock(Class<? extends ContainerScreen> gui, ItemStack item) {
+    public static void addGuiToBlock(Class<? extends HandledScreen> gui, ItemStack item) {
         TabUtils.putItemGui(gui, item);
     }
 
-    public static void addWorkBenchGui(Class<? extends ContainerScreen> gui) {
+    public static void addWorkBenchGui(Class<? extends HandledScreen> gui) {
         TabUtils.addWorkBenchGui(gui);
     }
 
@@ -66,8 +65,8 @@ public class HowManyItemsClient {
     }
 
     public void onTickInGUI(Minecraft mc, Screen guiscreen) {
-        if (guiscreen instanceof ContainerScreen) {
-            ContainerScreen screen = (ContainerScreen) guiscreen;
+        if (guiscreen instanceof HandledScreen) {
+            HandledScreen screen = (HandledScreen) guiscreen;
             if (Config.config.overlayEnabled) {
                 if (GuiOverlay.screen != screen || overlay == null || screen.width != overlay.width || screen.height != overlay.height) {
                     overlay = new GuiOverlay(screen);
@@ -80,12 +79,12 @@ public class HowManyItemsClient {
                     boolean getUses = Utils.isKeyDown(KeyBindings.pushUses);
                     ItemStack newFilter = null;
 
-                    class_564 scaledresolution = new class_564(mc.options, mc.displayWidth, mc.displayHeight);
-                    int i = scaledresolution.method_1857();
-                    int j = scaledresolution.method_1858();
+                    ScreenScaler scaledresolution = new ScreenScaler(mc.options, mc.displayWidth, mc.displayHeight);
+                    int i = scaledresolution.getScaledWidth();
+                    int j = scaledresolution.getScaledHeight();
                     int posX = (Mouse.getEventX() * i) / mc.displayWidth;
                     int posY = j - (Mouse.getEventY() * j) / mc.displayHeight - 1;
-                    newFilter = Utils.hoveredItem((ContainerScreen) guiscreen, posX, posY);
+                    newFilter = Utils.hoveredItem((HandledScreen) guiscreen, posX, posY);
                     if (newFilter == null) {
                         newFilter = GuiOverlay.hoverItem;
                     }
@@ -155,11 +154,11 @@ public class HowManyItemsClient {
             } else if (!GuiOverlay.searchBoxFocused() && getTabs().size() > 0) {
                 GuiRecipeViewer newgui = new GuiRecipeViewer(item, getUses, gui);
                 Utils.getMC().currentScreen = newgui;
-                class_564 scaledresolution = new class_564(Utils.getMC().options, Utils.getMC().displayWidth, Utils.getMC().displayHeight);
-                int i = scaledresolution.method_1857();
-                int j = scaledresolution.method_1858();
+                ScreenScaler scaledresolution = new ScreenScaler(Utils.getMC().options, Utils.getMC().displayWidth, Utils.getMC().displayHeight);
+                int i = scaledresolution.getScaledWidth();
+                int j = scaledresolution.getScaledHeight();
                 newgui.init(Utils.getMC(), i, j);
-                Utils.getMC().field_2821 = false;
+                Utils.getMC().skipGameRender = false;
             }
         }
     }
@@ -168,14 +167,14 @@ public class HowManyItemsClient {
         if (gui instanceof GuiRecipeViewer) {
             ((GuiRecipeViewer) gui).pushTabBlock(item);
         } else if (!GuiOverlay.searchBoxFocused() && getTabs().size() > 0) {
-            Utils.getMC().method_2133();
+            Utils.getMC().lockMouse();
             GuiRecipeViewer newgui = new GuiRecipeViewer(item, gui);
             Utils.getMC().currentScreen = newgui;
-            class_564 scaledresolution = new class_564(Utils.getMC().options, Utils.getMC().displayWidth, Utils.getMC().displayHeight);
-            int i = scaledresolution.method_1857();
-            int j = scaledresolution.method_1858();
+            ScreenScaler scaledresolution = new ScreenScaler(Utils.getMC().options, Utils.getMC().displayWidth, Utils.getMC().displayHeight);
+            int i = scaledresolution.getScaledWidth();
+            int j = scaledresolution.getScaledHeight();
             newgui.init(Utils.getMC(), i, j);
-            Utils.getMC().field_2821 = false;
+            Utils.getMC().skipGameRender = false;
         }
     }
 

--- a/src/main/java/net/glasslauncher/hmifabric/HowManyItemsServer.java
+++ b/src/main/java/net/glasslauncher/hmifabric/HowManyItemsServer.java
@@ -25,10 +25,10 @@ public class HowManyItemsServer {
 
     @EventListener
     public void handleLogin(PlayerLoginEvent event) {
-        if (((ModdedPacketHandler) event.player.field_255).isModded()) {
+        if (((ModdedPacketHandler) event.player.networkHandler).isModded()) {
             MessagePacket customData = new MessagePacket(Identifier.of("hmifabric:handshake"));
             customData.booleans = new boolean[]{true};
-            PacketHelper.sendTo(((MinecraftServer) FabricLoader.getInstance().getGameInstance()).field_2842.method_586(event.loginHelloPacket.username), customData);
+            PacketHelper.sendTo(((MinecraftServer) FabricLoader.getInstance().getGameInstance()).playerManager.getPlayer(event.loginHelloPacket.username), customData);
         }
     }
 
@@ -39,25 +39,25 @@ public class HowManyItemsServer {
     }
 
     public static void handleGivePacket(PlayerEntity player, MessagePacket packet) {
-        if (((MinecraftServer) FabricLoader.getInstance().getGameInstance()).field_2842.method_584(player.name)) {
+        if (((MinecraftServer) FabricLoader.getInstance().getGameInstance()).playerManager.isOperator(player.name)) {
             Object[] objects = packet.deserializeObjects();
             if(objects == null || objects.length < 1) {
-                player.method_490(Formatting.RED + "No items found to spawn?");
+                player.sendMessage(Formatting.RED + "No items found to spawn?");
                 return;
             }
             ItemStack itemInstance = (ItemStack) objects[0]; // Is this stupid? I have no idea.
             ItemEntity itemEntity = new ItemEntity(player.world, player.x, player.y, player.z, itemInstance);
-            player.world.method_210(itemEntity);
-            player.method_490(Formatting.GRAY + "Spawned some " + itemInstance.getItem().getTranslatedName() + "...");
+            player.world.spawnEntity(itemEntity);
+            player.sendMessage(Formatting.GRAY + "Spawned some " + itemInstance.getItem().getTranslatedName() + "...");
         }
-        else if (!((MinecraftServer) FabricLoader.getInstance().getGameInstance()).field_2842.method_584(player.name)) {
-            player.method_490(Formatting.RED + "You need to be opped in order to give yourself items!");
+        else if (!((MinecraftServer) FabricLoader.getInstance().getGameInstance()).playerManager.isOperator(player.name)) {
+            player.sendMessage(Formatting.RED + "You need to be opped in order to give yourself items!");
         }
     }
 
     public static void handleHealPacket(PlayerEntity player, MessagePacket packet) {
-        if (((MinecraftServer) FabricLoader.getInstance().getGameInstance()).field_2842.method_584(player.name)) {
-            player.method_939(Integer.MAX_VALUE/2); // High to allow mods that mess with player health to be supported.
+        if (((MinecraftServer) FabricLoader.getInstance().getGameInstance()).playerManager.isOperator(player.name)) {
+            player.heal(Integer.MAX_VALUE/2); // High to allow mods that mess with player health to be supported.
         }
     }
 }

--- a/src/main/java/net/glasslauncher/hmifabric/TabUtils.java
+++ b/src/main/java/net/glasslauncher/hmifabric/TabUtils.java
@@ -3,7 +3,7 @@ package net.glasslauncher.hmifabric;
 import net.glasslauncher.hmifabric.tabs.TabCrafting;
 import net.glasslauncher.hmifabric.tabs.TabRegistry;
 import net.glasslauncher.hmifabric.tabs.TabSmelting;
-import net.minecraft.client.gui.screen.container.ContainerScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.item.ItemStack;
 import net.modificationstation.stationapi.api.util.Identifier;
 
@@ -11,17 +11,17 @@ import java.util.*;
 
 public class TabUtils {
 
-    private static final Map<Class<? extends ContainerScreen>, ItemStack> guiToBlock = new HashMap<>();
+    private static final Map<Class<? extends HandledScreen>, ItemStack> guiToBlock = new HashMap<>();
 
-    public static ItemStack getItemFromGui(ContainerScreen screen) {
+    public static ItemStack getItemFromGui(HandledScreen screen) {
         return guiToBlock.get(screen.getClass());
     }
 
-    public static void putItemGui(Class<? extends ContainerScreen> gui, ItemStack item) {
+    public static void putItemGui(Class<? extends HandledScreen> gui, ItemStack item) {
         guiToBlock.put(gui, item);
     }
 
-    public static void addWorkBenchGui(Class<? extends ContainerScreen> gui) {
+    public static void addWorkBenchGui(Class<? extends HandledScreen> gui) {
         TabCrafting workbenchTab = (TabCrafting) TabRegistry.INSTANCE.get(Identifier.of(HowManyItems.MODID, "crafting"));
         //noinspection ConstantConditions If this is null, we have bigger issues.
         workbenchTab.guiCraftingStations.add(gui);

--- a/src/main/java/net/glasslauncher/hmifabric/Utils.java
+++ b/src/main/java/net/glasslauncher/hmifabric/Utils.java
@@ -94,7 +94,7 @@ public class Utils {
                     try {
                         int l = item.getTextureId(itemstack);
                         String s = TranslationStorage.getInstance().getClientTranslation(itemstack.getTranslationKey());
-                        if (s.length() == 0) s = itemstack.getTranslationKey() + "@" + l;
+                        if (s.isEmpty()) s = itemstack.getTranslationKey() + "@" + l;
                         if (dmg >= 4 && (s.contains(String.valueOf(dmg)) || s.contains(String.valueOf(dmg + 1)) || s.contains(String.valueOf(dmg - 1)))) {
                             break;
                         }

--- a/src/main/java/net/glasslauncher/hmifabric/Utils.java
+++ b/src/main/java/net/glasslauncher/hmifabric/Utils.java
@@ -4,12 +4,12 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.glasslauncher.hmifabric.event.HMIItemListRefreshEvent;
 import net.glasslauncher.hmifabric.mixin.access.ContainerBaseAccessor;
 import net.glasslauncher.hmifabric.tabs.Tab;
-import net.minecraft.class_583;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.container.ContainerScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.render.item.ItemRenderer;
+import net.minecraft.client.render.platform.Lighting;
 import net.minecraft.client.resource.language.TranslationStorage;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -47,7 +47,7 @@ public class Utils {
         }
         if (Config.config.showItemIDs && withID) {
             s += " " + item.itemId;
-            if (item.method_719()) s += ":" + item.getDamage();
+            if (item.hasSubtypes()) s += ":" + item.getDamage();
         }
         return s;
     }
@@ -58,7 +58,7 @@ public class Utils {
     }
 
     //Returns the item that the user is hovering in their inventory
-    public static ItemStack hoveredItem(ContainerScreen gui, int posX, int posY) {
+    public static ItemStack hoveredItem(HandledScreen gui, int posX, int posY) {
         try {
             Slot slotAtPosition = ((ContainerBaseAccessor) gui).invokeGetSlot(posX, posY);
             if (slotAtPosition != null) return slotAtPosition.getStack();
@@ -89,7 +89,7 @@ public class Utils {
                         }
                     }
                     try {
-                        int l = item.method_439(itemstack);
+                        int l = item.getTextureId(itemstack);
                         String s = TranslationStorage.getInstance().getClientTranslation(itemstack.getTranslationKey());
                         if (s.length() == 0) s = itemstack.getTranslationKey() + "@" + l;
                         if (dmg >= 4 && (s.contains(String.valueOf(dmg)) || s.contains(String.valueOf(dmg + 1)) || s.contains(String.valueOf(dmg - 1)))) {
@@ -122,7 +122,7 @@ public class Utils {
                             break;
                         }
                     }
-                    if (!itemstack.method_719()) {
+                    if (!itemstack.hasSubtypes()) {
                         continue;
                     }
                     addItemInOrder(allItems, itemstack);
@@ -243,9 +243,9 @@ public class Utils {
     public static void drawItemStack(int x, int y, ItemStack item, boolean drawOverlay) {
         localTextureBound = false;
         enableItemLighting();
-        itemRenderer.method_1487(getMC().textRenderer, getMC().textureManager, item, x, y);
+        itemRenderer.renderGuiItem(getMC().textRenderer, getMC().textureManager, item, x, y);
         if (drawOverlay) {
-            itemRenderer.method_1488(getMC().textRenderer, getMC().textureManager, item, x, y);
+            itemRenderer.renderGuiItemDecoration(getMC().textRenderer, getMC().textureManager, item, x, y);
         }
     }
 
@@ -255,7 +255,7 @@ public class Utils {
             GL11.glEnable(32826 /*GL_RESCALE_NORMAL_EXT*/);
             GL11.glPushMatrix();
             GL11.glRotatef(120F, 1.0F, 0.0F, 0.0F);
-            class_583.method_1930();
+            Lighting.turnOn();
             GL11.glPopMatrix();
             itemLighting = true;
         }
@@ -284,7 +284,7 @@ public class Utils {
 
     public static void postRender() {
         lighting = null;
-        class_583.method_1927();
+        Lighting.turnOff();
         enableLighting();
     }
 

--- a/src/main/java/net/glasslauncher/hmifabric/mixin/MixinContainerBase.java
+++ b/src/main/java/net/glasslauncher/hmifabric/mixin/MixinContainerBase.java
@@ -5,20 +5,20 @@ import net.glasslauncher.hmifabric.GuiOverlay;
 import net.glasslauncher.hmifabric.HowManyItemsClient;
 import net.glasslauncher.hmifabric.KeyBindings;
 import net.glasslauncher.hmifabric.Utils;
-import net.minecraft.client.gui.screen.container.ContainerScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import org.lwjgl.input.Keyboard;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(ContainerScreen.class)
+@Mixin(HandledScreen.class)
 public class MixinContainerBase {
 
     @Inject(method = "keyPressed(CI)V", at = @At(value = "HEAD"))
     private void keyPressed(char character, int key, CallbackInfo ci) {
         if (Keyboard.getEventKey() == KeyBindings.toggleOverlay.code && Utils.keybindValid(KeyBindings.toggleOverlay)) {
-            if (Utils.isGuiOpen(ContainerScreen.class) && !GuiOverlay.searchBoxFocused()) {
+            if (Utils.isGuiOpen(HandledScreen.class) && !GuiOverlay.searchBoxFocused()) {
                 Config.config.overlayEnabled = !Config.config.overlayEnabled;
                 if (HowManyItemsClient.thisMod.overlay != null) HowManyItemsClient.thisMod.overlay.toggle();
             }

--- a/src/main/java/net/glasslauncher/hmifabric/mixin/MixinGameRenderer.java
+++ b/src/main/java/net/glasslauncher/hmifabric/mixin/MixinGameRenderer.java
@@ -1,8 +1,8 @@
 package net.glasslauncher.hmifabric.mixin;
 
 import net.glasslauncher.hmifabric.HowManyItemsClient;
-import net.minecraft.class_555;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.render.GameRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -10,25 +10,25 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(class_555.class)
+@Mixin(GameRenderer.class)
 public class MixinGameRenderer {
 
     @Unique
     private long clock = 0L;
 
     @Shadow
-    private Minecraft field_2349;
+    private Minecraft client;
 
-    @Inject(method = "method_1844", at = @At(value = "TAIL"))
+    @Inject(method = "onFrameUpdate", at = @At(value = "TAIL"))
     private void onTick(float delta, CallbackInfo ci) {
         long newClock = 0L;
-        if (field_2349.world != null && HowManyItemsClient.thisMod != null) {
-            newClock = field_2349.world.getTime();
+        if (client.world != null && HowManyItemsClient.thisMod != null) {
+            newClock = client.world.getTime();
             if (newClock != clock) {
-                HowManyItemsClient.thisMod.onTickInGame(field_2349);
+                HowManyItemsClient.thisMod.onTickInGame(client);
             }
-            if (field_2349.currentScreen != null) {
-                HowManyItemsClient.thisMod.onTickInGUI(field_2349, field_2349.currentScreen);
+            if (client.currentScreen != null) {
+                HowManyItemsClient.thisMod.onTickInGUI(client, client.currentScreen);
             }
         }
         clock = newClock;

--- a/src/main/java/net/glasslauncher/hmifabric/mixin/access/ContainerBaseAccessor.java
+++ b/src/main/java/net/glasslauncher/hmifabric/mixin/access/ContainerBaseAccessor.java
@@ -1,12 +1,12 @@
 package net.glasslauncher.hmifabric.mixin.access;
 
-import net.minecraft.client.gui.screen.container.ContainerScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.screen.slot.Slot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
-@Mixin(ContainerScreen.class)
+@Mixin(HandledScreen.class)
 public interface ContainerBaseAccessor {
     @Invoker("getSlotAt")
     Slot invokeGetSlot(int i, int j);

--- a/src/main/java/net/glasslauncher/hmifabric/mixin/access/ShapedRecipeAccessor.java
+++ b/src/main/java/net/glasslauncher/hmifabric/mixin/access/ShapedRecipeAccessor.java
@@ -1,0 +1,16 @@
+package net.glasslauncher.hmifabric.mixin.access;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.ShapedRecipe;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ShapedRecipe.class)
+public interface ShapedRecipeAccessor {
+    @Accessor("width")
+    int getWidth();
+    @Accessor("height")
+    int getHeight();
+    @Accessor("input")
+    ItemStack[] getInput();
+}

--- a/src/main/java/net/glasslauncher/hmifabric/mixin/access/ShapelessRecipeAccessor.java
+++ b/src/main/java/net/glasslauncher/hmifabric/mixin/access/ShapelessRecipeAccessor.java
@@ -1,0 +1,13 @@
+package net.glasslauncher.hmifabric.mixin.access;
+
+import java.util.List;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.ShapelessRecipe;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ShapelessRecipe.class)
+public interface ShapelessRecipeAccessor {
+    @Accessor("input")
+    List<ItemStack> getInput();
+}

--- a/src/main/java/net/glasslauncher/hmifabric/tabs/Tab.java
+++ b/src/main/java/net/glasslauncher/hmifabric/tabs/Tab.java
@@ -1,6 +1,6 @@
 package net.glasslauncher.hmifabric.tabs;
 
-import net.minecraft.client.gui.screen.container.ContainerScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.resource.language.TranslationStorage;
 import net.minecraft.item.ItemStack;
 import net.modificationstation.stationapi.api.util.Namespace;
@@ -43,7 +43,7 @@ public abstract class Tab {
         return TranslationStorage.getInstance().getClientTranslation(getTabItem().getTranslationKey());
     }
 
-    public abstract Class<? extends ContainerScreen> getGuiClass();
+    public abstract Class<? extends HandledScreen> getGuiClass();
 
     public ArrayList<ItemStack> equivalentCraftingStations = new ArrayList<>();
 

--- a/src/main/java/net/glasslauncher/hmifabric/tabs/TabCrafting.java
+++ b/src/main/java/net/glasslauncher/hmifabric/tabs/TabCrafting.java
@@ -2,13 +2,13 @@ package net.glasslauncher.hmifabric.tabs;
 
 import net.glasslauncher.hmifabric.Utils;
 import net.minecraft.block.Block;
-import net.minecraft.class_516;
-import net.minecraft.class_564;
-import net.minecraft.class_585;
 import net.minecraft.client.InteractionManager;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.container.ContainerScreen;
+import net.minecraft.client.gui.screen.ingame.CraftingScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.client.render.Tessellator;
+import net.minecraft.client.util.ScreenScaler;
 import net.minecraft.entity.player.ClientPlayerEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
@@ -16,7 +16,6 @@ import net.minecraft.recipe.CraftingRecipe;
 import net.minecraft.recipe.CraftingRecipeManager;
 import net.minecraft.recipe.ShapelessRecipe;
 import net.minecraft.screen.slot.Slot;
-import net.modificationstation.stationapi.api.recipe.StationRecipe;
 import net.modificationstation.stationapi.api.util.Namespace;
 import org.lwjgl.input.Keyboard;
 
@@ -28,7 +27,7 @@ public class TabCrafting extends TabWithTexture {
     protected List<Object> recipes;
     private final Block tabBlock;
     private boolean isVanillaWorkbench = false; //THIS IS LAZY
-    public ArrayList<Class<? extends ContainerScreen>> guiCraftingStations = new ArrayList<>();
+    public ArrayList<Class<? extends HandledScreen>> guiCraftingStations = new ArrayList<>();
     public int recipeIndex;
 
     public TabCrafting(Namespace tabCreator) {
@@ -41,7 +40,7 @@ public class TabCrafting extends TabWithTexture {
             }
         }
         isVanillaWorkbench = true;
-        guiCraftingStations.add(class_516.class);
+        guiCraftingStations.add(CraftingScreen.class);
     }
 
     public TabCrafting(Namespace tabCreator, List<Object> recipesComplete, Block tabBlock) {
@@ -82,8 +81,8 @@ public class TabCrafting extends TabWithTexture {
     }
 
     @Override
-    public Class<? extends ContainerScreen> getGuiClass() {
-        return class_516.class;
+    public Class<? extends HandledScreen> getGuiClass() {
+        return CraftingScreen.class;
     }
 
     @Override
@@ -96,7 +95,7 @@ public class TabCrafting extends TabWithTexture {
             if (k < recipes.size()) {
                 try {
                     Object recipeObj = recipes.get(k);
-                    if (recipeObj instanceof StationRecipe) {
+                    /*if (recipeObj instanceof StationRecipe) {
                         StationRecipe recipe = (StationRecipe) recipes.get(k);
                         ItemStack[] list = recipe.getIngredients();
                         ItemStack[] outputArray = recipe.getOutputs();
@@ -105,7 +104,7 @@ public class TabCrafting extends TabWithTexture {
                             ItemStack item = list[j1];
                             items[j][j1 + 1] = item;
                             if (item != null && item.getDamage() == -1) {
-                                if (item.method_719()) {
+                                if (item.hasSubtypes()) {
                                     if (filter != null && item.itemId == filter.itemId) {
                                         items[j][j1 + 1] = new ItemStack(item.getItem(), 0, filter.getDamage());
                                     } else {
@@ -117,7 +116,7 @@ public class TabCrafting extends TabWithTexture {
                             }
                         }
 
-                    }
+                    }*/
                 } catch (Throwable throwable) {
                     throwable.printStackTrace();
                 }
@@ -144,17 +143,17 @@ public class TabCrafting extends TabWithTexture {
             recipes = recipesComplete;
         } else {
             for (Object o : recipesComplete) {
-                if (o instanceof StationRecipe) {
+                /*if (o instanceof StationRecipe) {
                     StationRecipe recipe = (StationRecipe) o;
                     if (!getUses) {
-                        if (Arrays.stream(recipe.getOutputs()).anyMatch(itemInstance -> filter.itemId == itemInstance.itemId && (itemInstance.getDamage() == filter.getDamage() || itemInstance.getDamage() < 0 || !itemInstance.method_719()))) {
+                        if (Arrays.stream(recipe.getOutputs()).anyMatch(itemInstance -> filter.itemId == itemInstance.itemId && (itemInstance.getDamage() == filter.getDamage() || itemInstance.getDamage() < 0 || !itemInstance.hasSubtypes()))) {
                             arraylist.add(o);
                         }
                     } else {
                         try {
                             ItemStack[] aitemstack = recipe.getIngredients();
                             for (ItemStack itemstack1 : aitemstack) {
-                                if (itemstack1 == null || filter.itemId != itemstack1.itemId || (itemstack1.method_719() && itemstack1.getDamage() != filter.getDamage()) && itemstack1.getDamage() >= 0) {
+                                if (itemstack1 == null || filter.itemId != itemstack1.itemId || (itemstack1.hasSubtypes() && itemstack1.getDamage() != filter.getDamage()) && itemstack1.getDamage() >= 0) {
                                     continue;
                                 }
                                 arraylist.add(o);
@@ -165,7 +164,7 @@ public class TabCrafting extends TabWithTexture {
                             exception.printStackTrace();
                         }
                     }
-                }
+                }*/
             }
             recipes = arraylist;
         }
@@ -181,7 +180,7 @@ public class TabCrafting extends TabWithTexture {
 
     @Override
     public Boolean drawSetupRecipeButton(Screen parent, ItemStack[] recipeItems) {
-        for (Class<? extends ContainerScreen> gui : guiCraftingStations) {
+        for (Class<? extends HandledScreen> gui : guiCraftingStations) {
             if (gui.isInstance(parent)) return true;
         }
         if (isVanillaWorkbench && (parent == null || isInv(parent))) {
@@ -198,12 +197,12 @@ public class TabCrafting extends TabWithTexture {
     public Boolean[] itemsInInventory(Screen parent, ItemStack[] recipeItems) {
         Boolean[] itemsInInv = new Boolean[slots.length - 1];
         List<Object> list;
-        if (parent instanceof ContainerScreen)
+        if (parent instanceof HandledScreen)
             //noinspection unchecked
-            list = ((ContainerScreen) parent).container.slots;
+            list = ((HandledScreen) parent).container.slots;
         else
             //noinspection unchecked
-            list = Utils.getMC().player.container.slots;
+            list = Utils.getMC().player.currentScreenHandler.slots;
         ItemStack[] aslot = new ItemStack[list.size()];
         for (int i = 0; i < list.size(); i++) {
             if (((Slot) list.get(i)).hasStack())
@@ -220,7 +219,7 @@ public class TabCrafting extends TabWithTexture {
             }
 
             for (ItemStack slot : aslot) {
-                if (slot != null && slot.count > 0 && slot.itemId == item.itemId && (slot.getDamage() == item.getDamage() || item.getDamage() < 0 || !item.method_719())) {
+                if (slot != null && slot.count > 0 && slot.itemId == item.itemId && (slot.getDamage() == item.getDamage() || item.getDamage() < 0 || !item.hasSubtypes())) {
                     slot.count -= 1;
                     itemsInInv[i - 1] = true;
                     continue recipe;
@@ -251,7 +250,7 @@ public class TabCrafting extends TabWithTexture {
             }
             int count = 0;
             for (ItemStack slot : aslot) {
-                if (slot != null && slot.count > 0 && slot.itemId == item.itemId && (slot.getDamage() == item.getDamage() || item.getDamage() < 0 || !item.method_719())) {
+                if (slot != null && slot.count > 0 && slot.itemId == item.itemId && (slot.getDamage() == item.getDamage() || item.getDamage() < 0 || !item.hasSubtypes())) {
                     count += slot.count;
                     slot.count = 0;
                 }
@@ -283,16 +282,16 @@ public class TabCrafting extends TabWithTexture {
     @Override
     public void setupRecipe(Screen parent, ItemStack[] recipeItems) {
         if (parent == null) {
-            Utils.getMC().method_2134();
-            class_564 scaledresolution = new class_564(Utils.getMC().options, Utils.getMC().displayWidth, Utils.getMC().displayHeight);
-            int i = scaledresolution.method_1857();
-            int j = scaledresolution.method_1858();
-            parent = new class_585(Utils.getMC().player);
+            Utils.getMC().unlockMouse();
+            ScreenScaler scaledresolution = new ScreenScaler(Utils.getMC().options, Utils.getMC().displayWidth, Utils.getMC().displayHeight);
+            int i = scaledresolution.getScaledWidth();
+            int j = scaledresolution.getScaledHeight();
+            parent = new InventoryScreen(Utils.getMC().player);
             Utils.getMC().currentScreen = parent;
             parent.init(Utils.getMC(), i, j);
-            Utils.getMC().field_2821 = false;
+            Utils.getMC().skipGameRender = false;
         }
-        ContainerScreen container = ((ContainerScreen) parent);
+        HandledScreen container = ((HandledScreen) parent);
         //noinspection unchecked
         List<Object> inventorySlots = container.container.slots;
 
@@ -343,7 +342,7 @@ public class TabCrafting extends TabWithTexture {
             while (!recipeSlot.hasStack() || (recipeSlot.getStack().count < recipeStackSize && recipeSlot.getStack().getMaxCount() > 1))
                 for (int inventorySlotIndex = recipeSlotIndex + 1; inventorySlotIndex < inventorySlots.size(); inventorySlotIndex++) {
                     Slot inventorySlot = (Slot) inventorySlots.get(inventorySlotIndex);
-                    if (inventorySlot.hasStack() && inventorySlot.getStack().itemId == item.itemId && (inventorySlot.getStack().getDamage() == item.getDamage() || item.getDamage() < 0 || !item.method_719())) {
+                    if (inventorySlot.hasStack() && inventorySlot.getStack().itemId == item.itemId && (inventorySlot.getStack().getDamage() == item.getDamage() || item.getDamage() < 0 || !item.hasSubtypes())) {
                         this.clickSlot(inventorySlotIndex, true, false);
                         if (isInv(parent) && recipeSlotIndex > 3) {
                             this.clickSlot(recipeSlotIndex - 1, false, false);

--- a/src/main/java/net/glasslauncher/hmifabric/tabs/TabGenericBlock.java
+++ b/src/main/java/net/glasslauncher/hmifabric/tabs/TabGenericBlock.java
@@ -2,7 +2,7 @@ package net.glasslauncher.hmifabric.tabs;
 
 import net.glasslauncher.hmifabric.Utils;
 import net.minecraft.block.Block;
-import net.minecraft.client.gui.screen.container.ContainerScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.item.ItemStack;
 import net.modificationstation.stationapi.api.util.Namespace;
 
@@ -72,7 +72,7 @@ public class TabGenericBlock extends Tab {
                 for (int i = 0; i < recipe.length; i++) {
                     items[j][i] = recipe[i];
                     if (recipe[i] != null && recipe[i].getDamage() == -1) {
-                        if (recipe[i].method_719()) {
+                        if (recipe[i].hasSubtypes()) {
                             if (filter != null && recipe[i].itemId == filter.itemId) {
                                 items[j][i] = new ItemStack(recipe[i].getItem(), 0, filter.getDamage());
                             } else {
@@ -120,14 +120,14 @@ public class TabGenericBlock extends Tab {
                 addRecipe = true;
             } else if (getUses) {
                 for (int i = 0; i < inputs.length; i++) {
-                    if (inputs[i].itemId == filter.itemId && (inputs[i].getDamage() == filter.getDamage() || inputs[i].getDamage() < 0 || !inputs[i].method_719())) {
+                    if (inputs[i].itemId == filter.itemId && (inputs[i].getDamage() == filter.getDamage() || inputs[i].getDamage() < 0 || !inputs[i].hasSubtypes())) {
                         addRecipe = true;
                         break;
                     }
                 }
             } else {
                 for (int i = 0; i < outputs.length; i++) {
-                    if (outputs[i].itemId == filter.itemId && (outputs[i].getDamage() == filter.getDamage() || outputs[i].getDamage() < 0 || !outputs[i].method_719())) {
+                    if (outputs[i].itemId == filter.itemId && (outputs[i].getDamage() == filter.getDamage() || outputs[i].getDamage() < 0 || !outputs[i].hasSubtypes())) {
                         addRecipe = true;
                         break;
                     }
@@ -178,7 +178,7 @@ public class TabGenericBlock extends Tab {
     }
 
     @Override
-    public Class<? extends ContainerScreen> getGuiClass() {
+    public Class<? extends HandledScreen> getGuiClass() {
         return null;
     }
 

--- a/src/main/java/net/glasslauncher/hmifabric/tabs/TabRegistry.java
+++ b/src/main/java/net/glasslauncher/hmifabric/tabs/TabRegistry.java
@@ -3,7 +3,7 @@ package net.glasslauncher.hmifabric.tabs;
 import com.mojang.serialization.Lifecycle;
 import net.glasslauncher.hmifabric.HowManyItems;
 import net.glasslauncher.hmifabric.TabUtils;
-import net.minecraft.client.gui.screen.container.ContainerScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.item.ItemStack;
 import net.modificationstation.stationapi.api.registry.*;
 import net.modificationstation.stationapi.api.util.Identifier;
@@ -27,7 +27,7 @@ public class TabRegistry extends SimpleRegistry<Tab> {
         public void draw(int x, int y, int recipeOnThisPageIndex, int cursorX, int cursorY) {}
 
         @Override
-        public Class<? extends ContainerScreen> getGuiClass() {
+        public Class<? extends HandledScreen> getGuiClass() {
             return null;
         }
     };

--- a/src/main/java/net/glasslauncher/hmifabric/tabs/TabSmelting.java
+++ b/src/main/java/net/glasslauncher/hmifabric/tabs/TabSmelting.java
@@ -1,8 +1,8 @@
 package net.glasslauncher.hmifabric.tabs;
 
 import net.minecraft.block.Block;
-import net.minecraft.class_524;
-import net.minecraft.client.gui.screen.container.ContainerScreen;
+import net.minecraft.client.gui.screen.ingame.FurnaceScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.recipe.SmeltingRecipeManager;
@@ -83,7 +83,7 @@ public class TabSmelting extends TabWithTexture {
                         int offset = i+1;
                         items[j][offset] = recipe[i];
                         if (recipe[i] != null && recipe[i].getDamage() == -1) {
-                            if (recipe[i].method_719()) {
+                            if (recipe[i].hasSubtypes()) {
                                 if (filter != null && recipe[i].itemId == filter.itemId) {
                                     items[j][offset] = new ItemStack(recipe[i].getItem(), 0, filter.getDamage());
                                 } else {
@@ -103,7 +103,7 @@ public class TabSmelting extends TabWithTexture {
                         ItemStack displayItem = new ItemStack(theHolyOneLiner);
                         items[j][offset] = displayItem;
                         if (recipe[i] != null && displayItem.getDamage() == -1) {
-                            if (displayItem.method_719()) {
+                            if (displayItem.hasSubtypes()) {
                                 if (filter != null && displayItem.itemId == filter.itemId) {
                                     items[j][offset] = new ItemStack(displayItem.getItem(), 0, filter.getDamage());
                                 } else {
@@ -140,8 +140,8 @@ public class TabSmelting extends TabWithTexture {
     }
 
     @Override
-    public Class<? extends ContainerScreen> getGuiClass() {
-        return class_524.class;
+    public Class<? extends HandledScreen> getGuiClass() {
+        return FurnaceScreen.class;
     }
 
     public void updateRecipesWithoutClear(ItemStack filter, Boolean getUses) {
@@ -186,7 +186,7 @@ public class TabSmelting extends TabWithTexture {
                     input = obj;
                 } else throw new ClassCastException("Invalid recipe item type " + obj.getClass().getName() + "!");
             }
-            if (input != null && (filter == null || (getUses && Arrays.stream(((ItemStack[]) input)).allMatch((inp) -> inp.itemId == filter.itemId)) || (!getUses && output.itemId == filter.itemId && (output.getDamage() == filter.getDamage() || output.getDamage() < 0 || !output.method_719())))) {
+            if (input != null && (filter == null || (getUses && Arrays.stream(((ItemStack[]) input)).allMatch((inp) -> inp.itemId == filter.itemId)) || (!getUses && output.itemId == filter.itemId && (output.getDamage() == filter.getDamage() || output.getDamage() < 0 || !output.hasSubtypes())))) {
                 recipes.add(new Object[]{output, input});
             } else if (filter == null) throw new ClassCastException("Invalid recipe item type " + input.getClass().getName() + "!");
         }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -7,7 +7,8 @@
   "description": "This is a port of HMI (commit 27) to fabric. Note that there is no mod integration.",
   "authors": [
     "Rek",
-    "calmilamsy"
+    "calmilamsy",
+    "HyperSpeeed"
   ],
   "contact": {
     "homepage": "https://glass-launcher.net/",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
     "stationapi:event_bus": [
       "net.glasslauncher.hmifabric.HowManyItems"
     ],
-    "gcapi": [
+    "gcapi3": [
       "net.glasslauncher.hmifabric.Config"
     ]
   },

--- a/src/main/resources/hmifabric.mixins.json
+++ b/src/main/resources/hmifabric.mixins.json
@@ -6,6 +6,8 @@
   "mixins": [
     "access.DrawableHelperAccessor",
     "access.LevelAccessor",
+    "access.ShapedRecipeAccessor",
+    "access.ShapelessRecipeAccessor",
     "MixinItemBase"
   ],
   "server": [


### PR DESCRIPTION
@calmilamsy 
This PR tries to upgrade HMI to the newest standards. In my experiments, it works beautifully with StationAPI 2.0.0-alpha.3 and GCAPI 3.0.0.
In particular, the following issues have been addressed:
- biny mappings have been updated to the newest build (I hope I have translated all the names correctly, though...)
- the config has been updated to GCAPI 3.0.0 since that is also what StationAPI uses
- tooltips are now properly supported through the usage of StationAPI's multiline tooltip renderer (my local build of Block Helper adds the mod name also to the item tooltips - but this was never rendered in HMI's tooltips.... Now it is; see screenshot below)
- crafting recipes have been updated to use `StationShape[d|less]Recipe` directly instead of the removed `StationRecipe` interface. This also meant that I had to add the Vanilla `Shape[d|less]Recipe` manually

![grafik](https://github.com/user-attachments/assets/29c0b748-c0b2-4cc7-9f21-1de1fe1a516a)
